### PR TITLE
Target group aspect update

### DIFF
--- a/lib/constructs/monitoring/aspects/target-group-monitoring-aspect.ts
+++ b/lib/constructs/monitoring/aspects/target-group-monitoring-aspect.ts
@@ -14,7 +14,7 @@ export interface TargetGroupMonitoringMetrics {
 }
 
 export interface TargetGroupMonitoringConfig {
-  responseTimeThreshold?: cdk.Duration;
+  responseTimeThreshold?: number;
   minHealthyHostsThreshold: number;
 }
 
@@ -31,7 +31,7 @@ export class TargetGroupMonitoringAspect extends AbstractMonitoringAspect<
   protected widgets(
     node: elbv2.ApplicationTargetGroup,
     config: TargetGroupMonitoringConfig,
-    metrics: TargetGroupMonitoringMetrics,
+    metrics: TargetGroupMonitoringMetrics
   ): cw.IWidget[] {
     return [
       dashboardSectionTitle(`TargetGroup ${node.targetGroupName}`),
@@ -41,7 +41,7 @@ export class TargetGroupMonitoringAspect extends AbstractMonitoringAspect<
         leftYAxis: dashboardSecondsAxis,
         leftAnnotations:
           config.responseTimeThreshold !== undefined
-            ? [alertAnnotation(config.responseTimeThreshold.toSeconds())]
+            ? [alertAnnotation(config.responseTimeThreshold)]
             : [],
         width: 12,
       }),
@@ -58,7 +58,7 @@ export class TargetGroupMonitoringAspect extends AbstractMonitoringAspect<
   protected alarms(
     node: elbv2.ApplicationTargetGroup,
     config: TargetGroupMonitoringConfig,
-    metrics: TargetGroupMonitoringMetrics,
+    metrics: TargetGroupMonitoringMetrics
   ): cw.Alarm[] {
     return [
       ...(config.responseTimeThreshold
@@ -67,7 +67,7 @@ export class TargetGroupMonitoringAspect extends AbstractMonitoringAspect<
               alarmName: `TargetGroupResponseTimeAlarm-${node.targetGroupName}`,
               metric: metrics.responseTime,
               evaluationPeriods: 5,
-              threshold: config.responseTimeThreshold.toSeconds(),
+              threshold: config.responseTimeThreshold,
               alarmDescription: `Response time is too high on ${node.targetGroupName}`,
             }),
           ]
@@ -87,6 +87,7 @@ export class TargetGroupMonitoringAspect extends AbstractMonitoringAspect<
     return {
       responseTime: node.metrics.targetResponseTime({
         period: cdk.Duration.minutes(1),
+        statistic: 'tm99',
       }),
       minHealthyHosts: node.metrics.healthyHostCount({
         period: cdk.Duration.minutes(1),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@condensetech/cdk-lib",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@condensetech/cdk-lib",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@condensetech/cdk-lib",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Update statistic for target group response time and manage non-integer numbers for response time threshold:
- Update statistic for target group response time TM99 https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html#Percentile-versus-Trimmed-Mean
- Manage non-integer numbers for response time threshold:

```ts
MonitoringFacade.of(otbSiteProduction.targetGroup)?.configTargetGroup(otbSiteProduction.targetGroup, {
  responseTimeThreshold: cdk.Duration.millis(600),
});
```
Error:

``error
Error: '600 millis' cannot be converted into a whole number of seconds.
``